### PR TITLE
Adds extended ID flag to extended CAN IDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,8 +460,8 @@ impl IsoTpSocket {
         let addr = CanAddr {
             _af_can: AF_CAN,
             if_index,
-            rx_id: if dst > 0x7FF {dst | EFF_FLAG} else {dst},
-            tx_id: if src > 0x7FF {src | EFF_FLAG} else {src},
+            rx_id: if dst > 0x7FF { dst | EFF_FLAG } else { dst },
+            tx_id: if src > 0x7FF { src | EFF_FLAG } else { src },
             _pgn: 0,
             _addr: 0,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ pub struct LinkLayerOptions {
     /// __u8 value : 8,12,16,20,24,32,48,64
     /// => rx path supports all LL_DL values
     tx_dl: u8,
-    /// set into struct canfd_frame.flags	*/
+    /// set into struct canfd_frame.flags
     /// at frame creation: e.g. CANFD_BRS
     /// Obsolete when the BRS flag is fixed
     /// by the CAN netdriver configuration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,8 +460,8 @@ impl IsoTpSocket {
         let addr = CanAddr {
             _af_can: AF_CAN,
             if_index,
-            rx_id: dst,
-            tx_id: src,
+            rx_id: if dst > 0x7FF {dst | EFF_FLAG} else {dst},
+            tx_id: if src > 0x7FF {src | EFF_FLAG} else {src},
             _pgn: 0,
             _addr: 0,
         };


### PR DESCRIPTION
Thanks for making this library. It's been very helpful!

I found that the library cannot directly use extended CAN ids and it is not documented anywhere that it is so. I am pretty new to this stuff and took a bit of reading to figure out the extended flag bit. 

This is a small change that should make it a bit easier. This makes it so that the library works with extended IDs for source and destination addresses regardless of whether the user set the correct flag.