### PR TITLE
Rename src and dst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # Change Log
+
+## [1.0.2]
+- Rename src and dst to rx_id and tx_id to avoid confusion
+- Bump nix dependency to `0.26`
+- Bump bitflags dependency to `2.3`
+- Bump embedded-can dependency to `0.4`
+
 ## [1.0.1]
 - Add public `FlowControlOptions::new`. Thanks Ashcon Mohseninia.
 - Bump nix dependency to `0.24`
+
 ## [1.0.0]
 - Breaking: src and dst identifier are now based on `embedded_can::Id`.
 - Bump nix dependency to `0.22`
+
 ## [0.1.1](https://github.com/marcelbuesing/socketcan-isotp/tree/1.0.1) (2020-02-18)
 - Critical FIX: Source and destination CAN identifiers were mixed up

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socketcan-isotp"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["marcelbuesing <buesing.marcel@googlemail.com>"]
 edition = "2018"
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 bitflags = "2.3"
-embedded-can = "0.3"
+embedded-can = "0.4"
 libc = "0.2"
 nix = "0.24"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["can", "socketcan", "iso-tp", "isotp", "iso-15762-2"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-bitflags = "1.2"
+bitflags = "2.3"
 embedded-can = "0.3"
 libc = "0.2"
 nix = "0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ maintenance = { status = "actively-developed" }
 bitflags = "2.3"
 embedded-can = "0.4"
 libc = "0.2"
-nix = "0.24"
+nix = "0.26"
 thiserror = "1.0"

--- a/examples/isotprecv.rs
+++ b/examples/isotprecv.rs
@@ -3,8 +3,8 @@ use socketcan_isotp::{self, IsoTpSocket, StandardId};
 fn main() -> Result<(), socketcan_isotp::Error> {
     let mut tp_socket = IsoTpSocket::open(
         "vcan0",
-        StandardId::new(0x123).expect("Invalid src id"),
-        StandardId::new(0x321).expect("Invalid dst id"),
+        StandardId::new(0x123).expect("Invalid rx id"),
+        StandardId::new(0x321).expect("Invalid tx id"),
     )?;
 
     let buffer = tp_socket.read()?;

--- a/examples/isotpsend.rs
+++ b/examples/isotpsend.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 fn main() -> Result<(), socketcan_isotp::Error> {
     let tp_socket = IsoTpSocket::open(
         "vcan0",
-        StandardId::new(0x321).expect("Invalid dst id"),
-        StandardId::new(0x123).expect("Invalid src id"),
+        StandardId::new(0x321).expect("Invalid rx id"),
+        StandardId::new(0x123).expect("Invalid tx id"),
     )?;
 
     loop {

--- a/examples/uds.rs
+++ b/examples/uds.rs
@@ -11,8 +11,8 @@ fn main() -> Result<(), socketcan_isotp::Error> {
     // Reader
     let mut reader_tp_socket = IsoTpSocket::open(
         "vcan0",
-        StandardId::new(0x7E8).expect("Invalid dst CAN ID"),
-        StandardId::new(0x77A).expect("Invalid src CAN ID"),
+        StandardId::new(0x7E8).expect("Invalid rx CAN ID"),
+        StandardId::new(0x77A).expect("Invalid tx CAN ID"),
     )?;
     std::thread::spawn(move || loop {
         let buffer = reader_tp_socket.read().expect("Failed to read from socket");
@@ -21,8 +21,8 @@ fn main() -> Result<(), socketcan_isotp::Error> {
 
     let tp_socket = IsoTpSocket::open(
         "vcan0",
-        StandardId::new(0x77A).expect("Invalid src CAN ID"),
-        StandardId::new(0x7E0).expect("Invalid dst CAN ID"),
+        StandardId::new(0x77A).expect("Invalid rx CAN ID"),
+        StandardId::new(0x7E0).expect("Invalid tx CAN ID"),
     )?;
 
     // 0x22 - Service Identifier for "Read data by identifier" request

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,11 +416,11 @@ impl IsoTpSocket {
     ///
     /// Usually the more common case, opens a socket can device by name, such
     /// as "vcan0" or "socan0".
-    pub fn open(ifname: &str, src: impl Into<Id>, dst: impl Into<Id>) -> Result<Self, Error> {
+    pub fn open(ifname: &str, rx_id: impl Into<Id>, tx_id: impl Into<Id>) -> Result<Self, Error> {
         Self::open_with_opts(
             ifname,
-            src,
-            dst,
+            rx_id,
+            tx_id,
             Some(IsoTpOptions::default()),
             Some(FlowControlOptions::default()),
             Some(LinkLayerOptions::default()),
@@ -433,8 +433,8 @@ impl IsoTpSocket {
     /// as "vcan0" or "socan0".
     pub fn open_with_opts(
         ifname: &str,
-        src: impl Into<Id>,
-        dst: impl Into<Id>,
+        rx_id: impl Into<Id>,
+        tx_id: impl Into<Id>,
         isotp_options: Option<IsoTpOptions>,
         rx_flow_control_options: Option<FlowControlOptions>,
         link_layer_options: Option<LinkLayerOptions>,
@@ -442,8 +442,8 @@ impl IsoTpSocket {
         let if_index = if_nametoindex(ifname)?;
         Self::open_if_with_opts(
             if_index.try_into().unwrap(),
-            src,
-            dst,
+            rx_id,
+            tx_id,
             isotp_options,
             rx_flow_control_options,
             link_layer_options,
@@ -453,11 +453,15 @@ impl IsoTpSocket {
     /// Open CAN ISO-TP device device by interface number.
     ///
     /// Opens a CAN device by kernel interface number.
-    pub fn open_if(if_index: c_int, src: impl Into<Id>, dst: impl Into<Id>) -> Result<Self, Error> {
+    pub fn open_if(
+        if_index: c_int,
+        rx_id: impl Into<Id>,
+        tx_id: impl Into<Id>,
+    ) -> Result<Self, Error> {
         Self::open_if_with_opts(
             if_index,
-            src,
-            dst,
+            rx_id,
+            tx_id,
             Some(IsoTpOptions::default()),
             Some(FlowControlOptions::default()),
             Some(LinkLayerOptions::default()),
@@ -469,17 +473,17 @@ impl IsoTpSocket {
     /// Opens a CAN device by kernel interface number.
     pub fn open_if_with_opts(
         if_index: c_int,
-        src: impl Into<Id>,
-        dst: impl Into<Id>,
+        rx_id: impl Into<Id>,
+        tx_id: impl Into<Id>,
         isotp_options: Option<IsoTpOptions>,
         rx_flow_control_options: Option<FlowControlOptions>,
         link_layer_options: Option<LinkLayerOptions>,
     ) -> Result<Self, Error> {
-        let rx_id = match src.into() {
+        let rx_id = match rx_id.into() {
             Id::Standard(standard_id) => standard_id.as_raw() as u32,
             Id::Extended(extended_id) => extended_id.as_raw() | EFF_FLAG,
         };
-        let tx_id = match dst.into() {
+        let tx_id = match tx_id.into() {
             Id::Standard(standard_id) => standard_id.as_raw() as u32,
             Id::Extended(extended_id) => extended_id.as_raw() | EFF_FLAG,
         };


### PR DESCRIPTION
- Rename src and dst and make consitent use of rx_id and tx_id instead. 
- Use latest version of crates
    - bitflags
    - embedded-can
    - nix

----

Sebastian Seiler on behalf of MBition GmbH

[Provider Information.](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)